### PR TITLE
Add Shopify service

### DIFF
--- a/api/shopify_service.dart
+++ b/api/shopify_service.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class ShopifyService {
+  static Future<List<dynamic>> fetchProducts() async {
+    try {
+      final baseUrl = dotenv.env['SHOPIFY_BASE_URL'];
+      final token = dotenv.env['SHOPIFY_ACCESS_TOKEN'];
+      final apiVersion = dotenv.env['SHOPIFY_API_VERSION'] ?? '2024-04';
+
+      if (baseUrl == null || token == null) {
+        throw Exception('Missing Shopify credentials');
+      }
+
+      final url = Uri.parse('$baseUrl/admin/api/$apiVersion/products.json');
+      final response = await http.get(
+        url,
+        headers: {
+          'X-Shopify-Access-Token': token,
+          'Content-Type': 'application/json',
+        },
+      );
+
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> data = json.decode(response.body);
+        return (data['products'] as List<dynamic>? ?? <dynamic>[]);
+      } else {
+        throw Exception('Shopify API error: ${response.statusCode}');
+      }
+    } catch (e) {
+      return Future.error('Failed to fetch products: $e');
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,8 +2,11 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:animated_text_kit/animated_text_kit.dart';
 import '../api/shopify_service.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await dotenv.load();
   runApp(const RPEGearApp());
 }
 


### PR DESCRIPTION
## Summary
- add an API service file for fetching products from Shopify
- load .env in `main()` for credentials

## Testing
- `dart format lib/main.dart api/shopify_service.dart`
- `flutter analyze` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841c48d5f0883208394e7362a28421d